### PR TITLE
172 skipped files

### DIFF
--- a/app/models/custom_slugs/slug_behavior.rb
+++ b/app/models/custom_slugs/slug_behavior.rb
@@ -31,9 +31,10 @@ module CustomSlugs
     # validate that the identifier creates a unique slug across all classes
     def check_slug
       return if identifier.empty?
+      # TODO: consider if we should change `slug_tesim` to `slug_ssim` so that a strict search is done
       possible_duplicates = ActiveFedora::Base.where(slug_tesim: slug)
       has_duplicates = if new_record?
-                         possible_duplicates.count.positive?
+                         possible_duplicates.any? { |pd| pd.slug == slug }
                        else
                          possible_duplicates.detect { |c| c.id != id }
                        end


### PR DESCRIPTION
Fixes #issuenumber ; refs #issuenumber

Present tense short summary (50 characters or less)
when a work is created with an identifier that doesn't end in an "s", then another work is created with the same identifier, but an "s" is added to the end...both works should be saved.

Changes proposed in this pull request:
* do not confuse a singular identifier with its plural version when creating slugs
*
*

@samvera/hyku-code-reviewers
