### PR TITLE
add the "originals" volume to the staging deploy

### DIFF
--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -28,6 +28,10 @@ extraVolumeMounts: &volMounts
   - name: uploads
     mountPath: /app/samvera/hyrax-webapp/tmp/network_files
     subPath: network-files
+  - name: uploads
+    mountPath: /app/samvera/hyrax-webapp/tmp/originals
+    subPath: originals
+
 
 ingress:
   enabled: true


### PR DESCRIPTION
refs #172 

### Present tense short summary (50 characters or less)
I need to test a bulkrax import using the server paths. on april 6 I added a csv and files to the "originals" mount on staging (seen below), but today that volume isn't there anymore. this change should make the volume permanent.

<img width="1311" alt="image" src="https://user-images.githubusercontent.com/29032869/230962121-0c1488db-ac7c-4da8-beee-be2d3e630f64.png">

### Changes proposed in this pull request:
* add an "originals" volume on staging 

### resources
- https://playbook-staging.notch8.com/en/learning-resources/kubernetes/krsync (step 2 under "prerequisites")

@samvera/hyku-code-reviewers
