### PR TITLE
186 production ready docker compose

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,61 @@
+CHROME_HOSTNAME=chrome
+CLIENT_USER_EMAIL=client@example.com
+CLIENT_USER_PASSWORD=password123
+DATABASE_ADAPTER=postgresql
+DATABASE_HOST=db
+DATABASE_NAME=hyku
+DATABASE_PASSWORD=DatabaseFTW
+DATABASE_TEST_NAME=hyku_test
+DATABASE_USER=postgres
+DB_HOST=db
+DB_PORT=5432
+FCREPO_HOST=fcrepo
+FCREPO_PORT=8080
+FEDORA_URL=http://fcrepo:8080/rest
+HYKU_ACTIVE_JOB_QUEUE_URL=sidekiq
+HYRAX_ACTIVE_JOB_QUEUE=sidekiq
+HYRAX_FITS_PATH=/app/fits/fits.sh
+INITIAL_ADMIN_EMAIL=admin@example.com
+INITIAL_ADMIN_PASSWORD=testing123
+INITIAL_USER_EMAIL=user@example.com
+INITIAL_USER_PASSWORD=testing123
+IN_DOCKER=true
+LD_LIBRARY_PATH=/opt/fits/tools/mediainfo/linux
+PASSENGER_APP_ENV=development
+RAILS_LOG_TO_STDOUT=true
+REDIS_HOST=redis
+ROB_EMAIL=rob@notch8.com
+ROB_PASSWORD=testing123
+SECRET_KEY_BASE=asdf
+SOLR_ADMIN_PASSWORD=SolrRocks
+SOLR_ADMIN_USER=solr
+SOLR_CLOUD_BOOTSTRAP=yes
+SOLR_COLLECTION=hydra-development
+SOLR_COLLECTION_NAME=hydra-development
+SOLR_CONFIGSET_NAME=hyku
+SOLR_ENABLE_AUTHENTICATION=yes
+SOLR_ENABLE_CLOUD_MODE=yes
+SOLR_HOST=solr
+SOLR_PORT=8983
+SOLR_URL="http://solr:SolrRocks@solr:8983/solr/"
+SUPPORT_EMAIL=support@notch8.com
+SUPPORT_PASSWORD=testing123
+TEST_USER_EMAIL=user@notch8.com
+TEST_USER_PASSWORD=testing123
+ZK_HOST=zoo:2181
+
+# Comment out these 5 for single tenancy / Uncomment for multi
+# HYKU_ADMIN_HOST=hyku.test
+# HYKU_ADMIN_ONLY_TENANT_CREATION=false
+# HYKU_DEFAULT_HOST=%{tenant}.hyku.test
+# HYKU_ROOT_HOST=hyku.test
+# HYKU_MULTITENANT=true
+# Comment out these 2 for multi tenancy / Uncomment for single
+HYKU_ROOT_HOST=hyku.test
+HYKU_MULTITENANT=false
+
+HYKU_BULKRAX_ENABLED=true
+
+# uncomment ENV vars set for Randy/non-docker setup
+# HYKU_CACHE_ROOT=/home/deploy/hyku/tmp/cache
+# HYKU_SSL_CONFIGURED=true

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,6 @@ config/environments/*.local.yml
 
 # Avatars and such
 public/uploads
-.env.*
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key

--- a/Gemfile
+++ b/Gemfile
@@ -91,6 +91,7 @@ group :development do
   gem 'easy_translate'
   gem 'scss_lint', require: false
   gem 'spring', '~> 1.7'
+  gem 'spring-commands-rspec'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1133,6 +1133,8 @@ GEM
       net-http-persistent (~> 4.0, >= 4.0.1)
       rdf (~> 3.1)
     spring (1.7.2)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
@@ -1286,6 +1288,7 @@ DEPENDENCIES
   simplecov
   solr_wrapper (~> 2.0)
   spring (~> 1.7)
+  spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   tether-rails
   turbolinks (~> 5)

--- a/app/indexers/app_indexer.rb
+++ b/app/indexers/app_indexer.rb
@@ -19,27 +19,26 @@ class AppIndexer < Hyrax::WorkIndexer
       solr_doc['title_ssi'] = object.title.first
       solr_doc['identifier_ssi'] = object.identifier.first
       solr_doc['is_page_of_ssim'] = ancestor_ids(object)
-      solr_doc['file_set_ids_ssim'] = all_decendent_file_sets(object)
+      solr_doc['file_set_ids_ssim'] = descendent_member_ids_for(object)
     end
   end
 
-  def all_decendent_file_sets(o)
-    # enables us to return parents when searching for child OCR
-    all_my_children = o.file_sets.map(&:id)
-    o.ordered_works&.each do |child|
-      all_my_children += all_decendent_file_sets(child)
+  def descendent_member_ids_for(object)
+    file_set_ids_array = object.file_sets.map(&:id)
+    object.ordered_works&.each do |child|
+      file_set_ids_array += descendent_member_ids_for(child)
     end
-    # enables us to return parents when searching for child metadata
-    all_my_children << o.member_ids
-    all_my_children.flatten!.uniq.compact
+    file_set_ids_array << object.members.map(&:to_param)
+    file_set_ids_array.flatten.uniq.compact
   end
 
-  def ancestor_ids(o)
-    a_ids = []
-    o.in_works.each do |work|
-      a_ids << work.id
-      a_ids += ancestor_ids(work) if work.is_child
+  def ancestor_ids(object)
+    ancestor_ids_array = []
+    object.in_works.each do |work|
+      ancestor_ids_array << work.to_param
+      ancestor_ids_array += ancestor_ids(work) if work.is_child
     end
-    a_ids
+    ancestor_ids_array << object.members.map(&:to_param)
+    ancestor_ids_array.flatten.uniq.compact
   end
 end

--- a/app/indexers/hyrax/file_set_indexer.rb
+++ b/app/indexers/hyrax/file_set_indexer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# OVERRIDE: Hyrax 2.9.1 to change all_text_timv to all_text_tsimv
+# OVERRIDE: Hyrax 2.9.1 to change all_text_tsimv to all_text_timv
 # Would like the OCR text to display in search results
 # so it needs to be a stored value
 
@@ -49,13 +49,15 @@ module Hyrax
 
     private
 
-      def ancestor_ids(o)
-        a_ids = []
-        o.in_works.each do |work|
-          a_ids << work.id
-          a_ids += ancestor_ids(work) if work.is_child
+      def ancestor_ids(object)
+        ancestor_ids_array = []
+        object.in_works.each do |work|
+          ancestor_ids_array << work.to_param
+          ancestor_ids_array += ancestor_ids(work) if work.is_child
         end
-        a_ids
+
+        # flatten nested array
+        ancestor_ids_array.flatten.uniq.compact
       end
 
       def digest_from_content

--- a/app/models/iiif_search_builder.rb
+++ b/app/models/iiif_search_builder.rb
@@ -17,6 +17,7 @@ class IiifSearchBuilder < Blacklight::SearchBuilder
   def ocr_search_params(solr_parameters = {})
     solr_parameters[:facet] = false
     solr_parameters[:hl] = true
+    solr_parameters[:qf] = blacklight_config.iiif_search[:full_text_field]
     solr_parameters[:'hl.fl'] = blacklight_config.iiif_search[:full_text_field]
     solr_parameters[:'hl.fragsize'] = 100
     solr_parameters[:'hl.snippets'] = 10
@@ -24,23 +25,23 @@ class IiifSearchBuilder < Blacklight::SearchBuilder
 
   private
 
-    # the {!lucene} gives us the OR syntax
-    def new_query
-      "{!lucene}#{interal_query(dismax_query)} #{interal_query(join_for_works_from_files)}"
-    end
+  # the {!lucene} gives us the OR syntax
+  def new_query
+    "{!lucene}#{interal_query(dismax_query)} #{interal_query(join_for_works_from_files)}"
+  end
 
-    # the _query_ allows for another parser (aka dismax)
-    def interal_query(query_value)
-      "_query_:\"#{query_value}\""
-    end
+  # the _query_ allows for another parser (aka dismax)
+  def interal_query(query_value)
+    "_query_:\"#{query_value}\""
+  end
 
-    # the {!dismax} causes the query to go against the query fields
-    def dismax_query
-      "{!dismax v=$user_query}"
-    end
+  # the {!dismax} causes the query to go against the query fields
+  def dismax_query
+    "{!dismax v=$user_query}"
+  end
 
-    # join from file id to work relationship solrized file_set_ids_ssim
-    def join_for_works_from_files
-      "{!join from=#{ActiveFedora.id_field} to=file_set_ids_ssim}#{dismax_query}"
-    end
+  # join from file id to work relationship solrized file_set_ids_ssim
+  def join_for_works_from_files
+    "{!join from=#{ActiveFedora.id_field} to=file_set_ids_ssim}#{dismax_query}"
+  end
 end

--- a/app/search_builders/hyrax/collection_member_search_builder_decorator.rb
+++ b/app/search_builders/hyrax/collection_member_search_builder_decorator.rb
@@ -1,0 +1,39 @@
+# OVERRIDE: Hyrax 2.9.6 adds filesets to search to allow full text search results
+
+# frozen_string_literal: true
+
+module Hyrax
+  module CollectionMemberSearchBuilderDecorator
+    Hyrax::CollectionMemberSearchBuilder.default_processor_chain += [:show_works_or_works_that_contain_files]
+
+    # These methods include the filesets in the search results
+    def show_works_or_works_that_contain_files(solr_parameters)
+      return if blacklight_params[:q].blank?
+      solr_parameters[:user_query] = blacklight_params[:q]
+      solr_parameters[:q] = new_query
+      solr_parameters[:defType] = 'lucene'
+    end
+
+    # the {!lucene} gives us the OR syntax
+    def new_query
+      "{!lucene}#{interal_query(dismax_query)} #{interal_query(join_for_works_from_files)}"
+    end
+
+    # the _query_ allows for another parser (aka dismax)
+    def interal_query(query_value)
+      "_query_:\"#{query_value}\""
+    end
+
+    # the {!dismax} causes the query to go against the query fields
+    def dismax_query
+      "{!dismax v=$user_query}"
+    end
+
+    # join from file id to work relationship solrized file_set_ids_ssim
+    def join_for_works_from_files
+      "{!join from=#{ActiveFedora.id_field} to=file_set_ids_ssim}#{dismax_query}"
+    end
+  end
+end
+
+Hyrax::CollectionMemberSearchBuilder.prepend(Hyrax::CollectionMemberSearchBuilderDecorator)

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -31,7 +31,7 @@ volumes:
     type: "cifs"
     device: "//136.165.112.51/Groups/Digital/HykuImports"
     o: "addr=136.165.112.51,ro,cached"
-    o: "uid=0,username=hyku,password=iuse4rchbtw!,file_mode=0777,dir_mode=0777"
+    o: "uid=0,username=${IMPORT_USER},password=${IMPORT_PASSWORD},file_mode=0777,dir_mode=0777"
 
 networks:
   internal:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,21 +1,16 @@
 version: '3.8'
 
 x-app: &app
-  build:
-    context: .
-    target: hyku-base
-    args:
-      - HYKU_BULKRAX_ENABLED=true
-    cache_from:
-        - ghcr.io/scientist-softserv/louisville-hyku:${TAG:-latest}
-  image: ghcr.io/scientist-softserv/louisville-hyku:${TAG:-latest}
+  image: ghcr.io/rkuehn-uofl/hyku:${TAG:-latest}
   env_file:
-    - .env.development
-  # NOTE: all common env variables moved to .env.development
+    - .env
+  # NOTE: all common env variables moved to .env
   volumes:
+    - HykuImports:/media/HykuImports
+    - node_modules:/app/samvera/hyrax-webapp/node_modules:cached
+    - uploads:/app/samvera/hyrax-webapp/public/uploads:cached
     - assets:/app/samvera/hyrax-webapp/public/assets:cached
     - cache:/app/samvera/hyrax-webapp/tmp/cache:cached
-    - uploads:/app/samvera/hyrax-webapp/public/uploads:cached
     - .:/app/samvera/hyrax-webapp
   networks:
     internal:
@@ -25,12 +20,18 @@ volumes:
   cache:
   db:
   fcrepo:
+  node_modules:
   redis:
   solr:
   uploads:
-  uv:
   zk:
   zoo:
+  HykuImports:
+   driver_opts:
+    type: "cifs"
+    device: "//136.165.112.51/Groups/Digital/HykuImports"
+    o: "addr=136.165.112.51,ro,cached"
+    o: "uid=0,username=hyku,password=iuse4rchbtw!,file_mode=0777,dir_mode=0777"
 
 networks:
   internal:
@@ -39,8 +40,8 @@ services:
   zoo:
     image: zookeeper:3.6.2
     ports:
-      - 2181:2181
-      - 7001:7000
+      - 127.0.0.1:2181:2181
+      - 127.0.0.1:7001:7000
     environment:
       - ZOO_MY_ID=1
       - ZOO_SERVERS=server.1=zoo:2888:3888;2181
@@ -57,15 +58,16 @@ services:
 
   solr:
     image: hyku/solr:8
-    build:
-      context: solr
-      dockerfile: Dockerfile
-    env_file:
-      - .env.development
     environment:
       - OOM=script
-      - VIRTUAL_PORT=8983
-      - VIRTUAL_HOST=solr.hyku.test
+      - SOLR_ADMIN_USER=solr
+      - SOLR_ADMIN_PASSWORD=SolrRocks
+      - SOLR_COLLECTION=hydra-development
+      - SOLR_CLOUD_BOOTSTRAP=yes
+      - SOLR_ENABLE_CLOUD_MODE=yes
+      - SOLR_ENABLE_AUTHENTICATION=yes
+      - ZK_HOST=zoo:2181
+      - SOLR_OPTS=-Dsolr.jetty.request.header.size=65535
     user: root
     command: bash -c "
       chown -R 8983:8983 /var/solr
@@ -73,16 +75,21 @@ services:
       && runuser -u solr -- solr-foreground"
     expose:
       - 8983
+    ports:
+      - 127.0.0.1:8983:8983
     volumes:
       - solr:/var/solr
+      - /home/deploy/hyku/solr/security.json:/var/solr/data/security.json
+      - /home/deploy/hyku/solr/limits.conf:/etc/security/limits.conf
+      - /home/deploy/Backups/solr:/media/backups
     networks:
       internal:
     healthcheck:
-      test: curl -sf http://$$SOLR_ADMIN_USER:$$SOLR_ADMIN_PASSWORD@solr:8983/solr/admin/cores?action=STATUS || exit 1
+      test: curl -sf http://$$SOLR_ADMIN_USER:$$SOLR_ADMIN_PASSWORD@localhost:8983/solr/admin/cores?action=STATUS || exit 1
       start_period: 10s
       interval: 20s
       timeout: 5s
-      retries: 6
+      retries: 3
     depends_on:
       zoo:
         condition: service_healthy
@@ -91,27 +98,26 @@ services:
     image: ghcr.io/samvera/fcrepo4:4.7.5
     volumes:
       - fcrepo:/data:cached
+      - /home/deploy/Backups/fedora:/media/backups
     env_file:
-      - .env.development
+      - .env
     environment:
-      - VIRTUAL_PORT=8080
-      - VIRTUAL_HOST=fcrepo.hyku.test
-      - JAVA_OPTS=${JAVA_OPTS} -Dfcrepo.modeshape.configuration="classpath:/config/file-simple/repository.json" -Dfcrepo.object.directory="/data/objects" -Dfcrepo.binary.directory="/data/binaries"
+      - JAVA_OPTS=${JAVA_OPTS} -Dfcrepo.modeshape.configuration="classpath:/config/jdbc-postgresql/repository.json" -Dfcrepo.postgresql.host=db -Dfcrepo.postgresql.username=${DB_USER} -Dfcrepo.postgresql.password=${DB_PASSWORD:-hyku} -Dfcrepo.object.directory="/data/objects" -Dfcrepo.binary.directory="/data/fcrepo.binary.directory" -Djava.io.tmpdir="/data/tmp"
     expose:
       - 8080
+    ports:
+      - 127.0.0.1:8080:8080
     networks:
       internal:
 
   db:
     image: postgres:11.1
     env_file:
-      - .env.development
+      - .env
     environment:
       - POSTGRES_DB=${DATABASE_NAME}
       - POSTGRES_PASSWORD=${DATABASE_PASSWORD}
       - POSTGRES_USER=${DATABASE_USER}
-      - VIRTUAL_PORT=5432
-      - VIRTUAL_HOST=db.hyku.test
     volumes:
       - db:/var/lib/postgresql/data
     networks:
@@ -121,8 +127,6 @@ services:
     <<: *app
     # command: sh -l -c "bundle && yarn install && bundle exec puma -v -b tcp://0.0.0.0:3000"
     environment:
-      - VIRTUAL_PORT=3000
-      - VIRTUAL_HOST=.hyku.test
       - TMPDIR=/app/samvera/hyrax-webapp/tmp/uploads
     depends_on:
       db:
@@ -137,28 +141,18 @@ services:
         condition: service_started
       check_volumes:
         condition: service_started
-      chrome:
-        condition: service_started
       worker:
         condition: service_started
       initialize_app:
         condition: service_completed_successfully
     expose:
       - 3000
+    ports:
+      - 127.0.0.1:3000:3000
 
   worker:
     <<: *app
-    image: ghcr.io/scientist-softserv/louisville-hyku/worker:${TAG:-latest}
-    build:
-      context: .
-      target: hyku-worker
-      args:
-        - HYKU_BULKRAX_ENABLED=true
-      cache_from:
-        - ghcr.io/scientist-softserv/louisville-hyku:${TAG:-latest}
-        - ghcr.io/scientist-softserv/louisville-hyku/worker:${TAG:-latest}
-    # command: bash -l -c "bundle exec sidekiq"
-    command: bundle exec sidekiq
+    image: ghcr.io/rkuehn-uofl/hyku/worker:${TAG:-latest}
     depends_on:
       check_volumes:
         condition: service_completed_successfully
@@ -175,8 +169,6 @@ services:
       zoo:
         condition: service_started
 
-
-
   # Do not recurse through all of tmp. derivitives will make booting
   # very slow and eventually just time out as data grows
   check_volumes:
@@ -188,6 +180,7 @@ services:
         chown -R app:app /app/samvera/hyrax-webapp/public/uploads &&
         chown -R app:app /app/samvera/hyrax-webapp/public/assets &&
         chown -R app:app /app/samvera/hyrax-webapp/tmp/cache
+        chown -R app:app /app/samvera/hyrax-webapp/db/schema.rb
 
   initialize_app:
     <<: *app
@@ -217,18 +210,3 @@ services:
       - redis:/data
     networks:
       internal:
-
-  chrome:
-    # password is 'secret'
-    image: seleniarm/standalone-chromium:latest
-    logging:
-      driver: none
-    volumes:
-      - /dev/shm:/dev/shm
-    shm_size: 3G
-    networks:
-      internal:
-    environment:
-      - JAVA_OPTS=-Dwebdriver.chrome.whitelistedIps=
-      - VIRTUAL_PORT=7900
-      - VIRTUAL_HOST=chrome.hyku.test

--- a/solr/config/schema.xml
+++ b/solr/config/schema.xml
@@ -340,7 +340,7 @@
     destination field is to use the dynamic field syntax.
     copyField also supports a maxChars to copy setting.  -->
 
-   <!-- <copyField source="*_tesim" dest="all_text_timv" maxChars="3000"/> -->
+   <!-- <copyField source="*_tesim" dest="all_text_tsimv" maxChars="3000"/> -->
    <!-- for suggestions -->
    <copyField source="*_tesim" dest="suggest"/>
    <copyField source="*_ssim" dest="suggest"/>

--- a/solr/config/solrconfig.xml
+++ b/solr/config/solrconfig.xml
@@ -107,7 +107,7 @@
           subject_tesim
         </str>
         <str name="pf">
-          all_text_timv^10
+          all_text_tsimv^10
         </str>
 
        <str name="author_qf">

--- a/spec/indexers/app_indexer_spec.rb
+++ b/spec/indexers/app_indexer_spec.rb
@@ -1,12 +1,40 @@
 # frozen_string_literal: true
 
 RSpec.describe AppIndexer do
-  subject(:solr_document) { service.generate_solr_document }
+  let(:file_set1) { create(:file_set, id: '123') }
+  let(:file_set2) { create(:file_set, id: '456') }
+  let(:file_set3) { create(:file_set, id: '789') }
 
-  let(:service) { described_class.new(work) }
-  let(:work) { create(:work) }
+  let(:child_work1) do
+    create(:work, is_child: true).tap do |work|
+      work.members << file_set1
+      work.save!
+    end
+  end
 
-  context "account_cname_tesim" do
+  let(:child_work2) do
+    create(:work, is_child: true).tap do |work|
+      work.members << file_set2
+      work.save!
+    end
+  end
+
+  let(:parent_work) do
+    create(:work).tap do |work|
+      work.members << file_set3
+      work.members += [file_set1, file_set2]
+      work.ordered_members += [child_work1, child_work2]
+      work.save!
+    end
+  end
+
+  let(:service) { described_class.new(parent_work.reload) }
+  let(:child_work1_solr_document) { AppIndexer.new(child_work1.reload).generate_solr_document }
+  let(:child_work2_solr_document) { AppIndexer.new(child_work2.reload).generate_solr_document }
+
+  describe '#generate_solr_document' do
+    subject(:solr_document) { service.generate_solr_document }
+
     let(:account) { create(:account, cname: 'hyky-test.me') }
 
     before do
@@ -16,14 +44,49 @@ RSpec.describe AppIndexer do
 
       Apartment::Tenant.switch!(account.tenant) do
         Site.update(account: account)
-        work
+        parent_work
+        child_work1
       end
     end
 
     it "indexer has the account_cname" do
       expect(solr_document.fetch("account_cname_tesim")).to eq(account.cname)
     end
-  end
 
-  include_examples("indexes_custom_slugs")
+    it 'indexes the parent_work custom fields' do
+      expect(solr_document.fetch('is_child_bsi')).to eq parent_work.is_child
+      expect(solr_document.fetch('title_ssi')).to eq parent_work.title.first
+      expect(solr_document.fetch('identifier_ssi')).to eq parent_work.identifier.first
+      # rubocop:disable Metrics/LineLength
+      expected_array = [file_set1.to_param, file_set2.to_param, file_set3.to_param, child_work1.to_param, child_work2.to_param]
+      # rubocop:enable Metrics/LineLength
+      expect(solr_document.fetch('file_set_ids_ssim')).to match_array(expected_array)
+    end
+
+    it 'indexes the childs custom fields' do
+      expect(child_work1_solr_document.fetch('is_page_of_ssim')).to include(parent_work.to_param)
+      expect(child_work1_solr_document.fetch('is_child_bsi')).to eq child_work1.is_child
+      expected_array = [file_set1.to_param]
+      expect(child_work1_solr_document.fetch('file_set_ids_ssim')).to match_array(expected_array)
+    end
+
+    describe '#descendent_member_ids_for' do
+      it 'returns an array of all descendant file set ids' do
+        # rubocop:disable Metrics/LineLength
+        expected_array = [file_set1.to_param, file_set2.to_param, file_set3.to_param, child_work1.to_param, child_work2.to_param]
+        # rubocop:enable Metrics/LineLength
+        expect(service.descendent_member_ids_for(parent_work)).to match_array(expected_array)
+      end
+    end
+
+    describe '#ancestor_ids' do
+      it 'returns an array of all ancestor slugs/ids' do
+        # rubocop:disable Metrics/LineLength
+        expected_array = [file_set1.to_param, file_set2.to_param, file_set3.to_param, child_work1.to_param, child_work2.to_param]
+        # rubocop:enable Metrics/LineLength
+        expect(service.ancestor_ids(parent_work)).to match_array(expected_array)
+      end
+    end
+    include_examples("indexes_custom_slugs")
+  end
 end


### PR DESCRIPTION
Randy - this needs some feedback from you. 

1) we seperated out the production docker-compose from the dev one. This means on your server you'd change your docker-compose commands to `docker-compose -f docker-compose.production.yml`. We often set an alias on the server for this so that `dc='docker-compose -f docker-compose.production.yml'`

2) we generally do not build the images on the production box, but instead build in CI and pull the images down. It looks like you probably have been building on the prod box. If you want to keep doing that, we can add support for building back in to the production docker-compose. Is that something you want?