### PR TITLE
Amending REFS for bullet point

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,8 @@
 # Story
 
-Refs #issuenumber
+Refs:
+
+- #issuenumber
 
 # Expected Behavior Before Changes
 


### PR DESCRIPTION
This is a meta adjustment.  The reason to encourage bullet points is that this will "unfurl" the ref to it's full name and a visual indicator of whether it's closed or not.

The QA test is to submit a new PR and view the template.  However, given that this does not impact clients, this can skip testing.