### PR TITLE
add ENV variables to helm for postgres-backed fedora

### DIFF
--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -94,6 +94,8 @@ extraEnvVars: &envVars
     value: postgres
   - name: FCREPO_BASE_PATH
     value: /louisville
+  - name: FCREPO_DB
+    value: fcrepo
   - name: FCREPO_HOST
     value: fcrepo.staging-fcrepo.svc.cluster.local:8080
   - name: FCREPO_PATH
@@ -102,10 +104,18 @@ extraEnvVars: &envVars
     value: http://fcrepo.staging-fcrepo.svc.cluster.local:8080/rest
   - name: IN_DOCKER
     value: "true"
+  - name: JAVA_OPTIONS
+    value: -Dfcrepo.postgresql.host=$DATABASE_HOST -Dfcrepo.postgresql.database=$FCREPO_DB -Dfcrepo.postgresql.port=5432 -Dfcrepo.postgresql.username=$DATABASE_USER -Dfcrepo.postgresql.password=$DATABASE_PASSWORD -Dfcrepo.object.directory="/data/objects" -Dfcrepo.binary.directory="/data/binaries"
   - name: LD_LIBRARY_PATH
     value: /app/fits/tools/mediainfo/linux
   - name: PASSENGER_APP_ENV
     value: production
+  - name: POSTGRES_DB
+    value: $DATABASE_NAME
+  - name: POSTGRES_PASSWORD
+    value: $DATABASE_PASSWORD
+  - name: POSTGRES_USER
+    value: $DATABASE_USER
   - name: RAILS_CACHE_STORE_URL
     value: redis://:$REDIS_PASSWORD@louisville-hyku-staging-redis-master:6379/louisville
   - name: RAILS_ENV


### PR DESCRIPTION
# Story

Refs:

- #186 

Follow up to https://github.com/scientist-softserv/louisville-hyku/pull/192

# Expected Behavior Before Changes

Staging deploy does not have ENV variables for a postgres-backed Fedora database 

# Expected Behavior After Changes

Staging deploy has ENV variables for a postgres-backed Fedora database 